### PR TITLE
Update reverse_proxy.md

### DIFF
--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -83,7 +83,7 @@ location /ws {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
+    proxy_set_header Connection "upgrade";
 }
 ```
 


### PR DESCRIPTION
Change 
`proxy_set_header Connection "connection_upgrade";` to `proxy_set_header Connection "upgrade";`
Fixes error: Invalid nginx configuration: nginx: [emerg] unknown "connection_upgrade" variable nginx: configuration file /etc/nginx/nginx.conf test failed